### PR TITLE
Remove log warnings on Request macro registrations

### DIFF
--- a/src/CorrelationIdServiceProvider.php
+++ b/src/CorrelationIdServiceProvider.php
@@ -91,8 +91,6 @@ class CorrelationIdServiceProvider extends ServiceProvider
 
                 return $this->attributes->get('uuid');
             });
-        } else {
-            Log::warning('Request::getUniqueId() already exists, skipping macro registration.');
         }
     }
 
@@ -107,8 +105,6 @@ class CorrelationIdServiceProvider extends ServiceProvider
                 // Sanitize the correlation id as a safety precaution
                 return preg_replace(CorrelationIdServiceProvider::$sanitize, '', $this->header(CorrelationIdServiceProvider::getCorrelationIdHeaderName()));
             });
-        } else {
-            Log::warning('Request::getCorrelationId() already exists, skipping macro registration.');
         }
     }
 
@@ -123,8 +119,6 @@ class CorrelationIdServiceProvider extends ServiceProvider
                 // Sanitize the correlation id as a safety precaution
                 return preg_replace(CorrelationIdServiceProvider::$sanitize, '', $this->header(CorrelationIdServiceProvider::getClientRequestIdHeaderName()));
             });
-        } else {
-            Log::warning('Request::getClientRequestId() already exists, skipping macro registration.');
         }
     }
 }


### PR DESCRIPTION
as discussed in #10, Laravel is sometimes bootstrapped twice during the same request cycle. This happens e.g. in `php artisan config:cache` or `php artisan route:cache`. We should not log any warnings when trying to re-register macros in `CorrelationIdServiceProvider`, just silently ignore.